### PR TITLE
Added root_node_ordering flag to MPTTOptions, to allow for concurrency

### DIFF
--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -21,7 +21,7 @@ from mptt.compat import cached_field_value
 from mptt.exceptions import CantDisableUpdates, InvalidMove
 from mptt.querysets import TreeQuerySet
 from mptt.signals import node_moved
-from mptt.utils import _get_tree_model
+from mptt.utils import _get_tree_model, clean_tree_ids
 
 
 __all__ = ("TreeManager",)
@@ -489,6 +489,8 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         set the node's parent and let mptt call this during save.
         """
 
+        root_node_ordering = self.model._mptt_meta.root_node_ordering
+
         if node.pk and not allow_existing_pk and self.filter(pk=node.pk).exists():
             raise ValueError(_("Cannot insert a node which has already been saved."))
 
@@ -507,11 +509,18 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             target_tree_id = getattr(target, self.tree_id_attr)
             if position == "left":
                 tree_id = target_tree_id
-                space_target = target_tree_id - 1
+                if root_node_ordering:
+                    space_target = target_tree_id - 1
+                else:
+                    space_target = self._get_next_tree_id()
             else:
-                tree_id = target_tree_id + 1
+                if root_node_ordering:
+                    tree_id = target_tree_id + 1
+                else:
+                    tree_id = self._get_next_tree_id()
                 space_target = target_tree_id
-            self._create_tree_space(space_target)
+            if root_node_ordering:
+                self._create_tree_space(space_target)
 
             setattr(node, self.left_attr, 1)
             setattr(node, self.right_attr, 2)
@@ -827,9 +836,13 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
 
     def _get_next_tree_id(self):
         """
-        Determines the next largest unused tree id for the tree managed
-        by this manager.
+        Determines the next largest unused tree id for the tree managed by this manager, unless root_node_ordering is
+        disabled.  If root_node_ordering is disabled a new default value will be generated for the field (by default
+        this will be a new UUID).
         """
+        if not self.model._mptt_meta.root_node_ordering:
+            return self.model._meta.get_field(self.tree_id_attr).default()
+
         max_tree_id = list(self.aggregate(Max(self.tree_id_attr)).values())[0]
         max_tree_id = max_tree_id or 0
         return max_tree_id + 1
@@ -846,6 +859,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         qn = connection.ops.quote_name
 
         opts = self.model._meta
+        root_ordering = self.model._mptt_meta.root_node_ordering
         inter_tree_move_query = """
         UPDATE %(table)s
         SET %(level)s = CASE
@@ -880,6 +894,12 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         right = getattr(node, self.right_attr)
         gap_size = right - left + 1
         gap_target_left = left - 1
+        new_tree_id, current_tree_id = clean_tree_ids(
+            new_tree_id,
+            getattr(node, self.tree_id_attr),
+            root_ordering=root_ordering,
+            vendor=connection.vendor,
+        )
         params = [
             left,
             right,
@@ -897,7 +917,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             left_right_change,
             gap_target_left,
             gap_size,
-            getattr(node, self.tree_id_attr),
+            current_tree_id,
         ]
 
         cursor = connection.cursor()
@@ -949,6 +969,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             raise InvalidMove(_("A node may not be made a sibling of itself."))
 
         opts = self.model._meta
+        root_ordering = self.model._mptt_meta.root_node_ordering
         tree_id = getattr(node, self.tree_id_attr)
         target_tree_id = getattr(target, self.tree_id_attr)
 
@@ -1012,10 +1033,17 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                 "tree_id": qn(opts.get_field(self.tree_id_attr).column),
             }
 
+            cleaned_tree_id, cleaned_new_tree_id = clean_tree_ids(
+                tree_id,
+                new_tree_id,
+                root_ordering=root_ordering,
+                vendor=connection.vendor,
+            )
+
             cursor = connection.cursor()
             cursor.execute(
                 root_sibling_query,
-                [tree_id, new_tree_id, shift, lower_bound, upper_bound],
+                [cleaned_tree_id, cleaned_new_tree_id, shift, lower_bound, upper_bound],
             )
             setattr(node, self.tree_id_attr, new_tree_id)
 
@@ -1032,6 +1060,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             qn = connection.ops.quote_name
 
             opts = self.model._meta
+            root_ordering = self.model._mptt_meta.root_node_ordering
             space_query = """
             UPDATE %(table)s
             SET %(left)s = CASE
@@ -1051,7 +1080,18 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             }
             cursor = connection.cursor()
             cursor.execute(
-                space_query, [target, size, target, size, tree_id, target, target]
+                space_query,
+                [
+                    target,
+                    size,
+                    target,
+                    size,
+                    clean_tree_ids(
+                        tree_id, root_ordering=root_ordering, vendor=connection.vendor
+                    ),
+                    target,
+                    target,
+                ],
             )
 
     def _move_child_node(self, node, target, position):
@@ -1186,6 +1226,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         qn = connection.ops.quote_name
 
         opts = self.model._meta
+        root_ordering = self.model._mptt_meta.root_node_ordering
         # The level update must come before the left update to keep
         # MySQL happy - left seems to refer to the updated value
         # immediately after its update has been specified in the query
@@ -1235,7 +1276,9 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                 left_boundary,
                 right_boundary,
                 gap_size,
-                tree_id,
+                clean_tree_ids(
+                    tree_id, root_ordering=root_ordering, vendor=connection.vendor
+                ),
             ],
         )
 
@@ -1286,6 +1329,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         qn = connection.ops.quote_name
 
         opts = self.model._meta
+        root_ordering = self.model._mptt_meta.root_node_ordering
         move_tree_query = """
         UPDATE %(table)s
         SET %(level)s = %(level)s - %%s,
@@ -1301,6 +1345,10 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             "tree_id": qn(opts.get_field(self.tree_id_attr).column),
         }
 
+        cleaned_tree_id, cleaned_new_tree_id = clean_tree_ids(
+            tree_id, new_tree_id, root_ordering=root_ordering, vendor=connection.vendor
+        )
+
         cursor = connection.cursor()
         cursor.execute(
             move_tree_query,
@@ -1308,10 +1356,10 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                 level_change,
                 left_right_change,
                 left_right_change,
-                new_tree_id,
+                cleaned_new_tree_id,
                 left,
                 right,
-                tree_id,
+                cleaned_tree_id,
             ],
         )
 

--- a/mptt/utils.py
+++ b/mptt/utils.py
@@ -7,6 +7,7 @@ import csv
 import itertools
 import sys
 
+from django.utils.encoding import smart_str
 from django.utils.translation import gettext as _
 
 
@@ -210,6 +211,46 @@ def _get_tree_model(model_class):
         if hasattr(b, "_mptt_meta") and not (b._meta.abstract or b._meta.proxy):
             return b
     return None
+
+
+def clean_tree_ids(*tree_ids, **kwargs):
+    """
+    Cleans tree ids that are UUIDFields.  PostgreSQL uses a `uuid` column type that has dashes stored in it, all the
+    other backends use a string representation with the dashes stripped out.  This method simply abstracts away that
+    logic.
+
+    Args:
+        *tree_ids: tree_ids you wish to clean
+        **kwargs:
+            root_ordering: be a boolean specifying whether root node ordering is enabled, default is False.  If True,
+                this method will simply return the tree_ids as they were sent in.
+            vendor: string value representing the database vendor in use (ex 'postgresql' or 'mysql').  use django's
+                Connection.vendor as it will provide the vendor name safely.
+
+    Returns:
+        The cleaned tree_ids in tuple form if multiple ids were passed in, otherwise the singular cleaned tree id.
+    """
+    root_ordering = kwargs.get("root_ordering", False)
+    vendor = kwargs.get("vendor")
+
+    if root_ordering:
+        return tree_ids if len(tree_ids) > 1 else tree_ids[0]
+
+    def _clean_tree_id(tree_id, vendor):
+        return (
+            smart_str(tree_id).replace("-", "") if vendor != "postgresql" else tree_id
+        )
+
+    results = tuple()
+    for tree_id in tree_ids:
+        cleaned_tree_id = _clean_tree_id(tree_id, vendor)
+        if not results:
+            results = cleaned_tree_id
+        elif isinstance(results, tuple):
+            results += (cleaned_tree_id,)
+        else:
+            results = (results, cleaned_tree_id)
+    return results
 
 
 def get_cached_trees(queryset):

--- a/tests/myapp/fixtures/unordered_categories.json
+++ b/tests/myapp/fixtures/unordered_categories.json
@@ -1,0 +1,132 @@
+[
+  {
+    "pk": 1,
+    "model": "myapp.unorderedcategory",
+    "fields": {
+      "rght": 20,
+      "name": "PC & Video Games",
+      "category_uuid": "6263ac21-f08b-4b44-9462-0489c56e0d3d",
+      "parent": null,
+      "level": 0,
+      "lft": 1,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 2,
+    "model": "myapp.unorderedcategory",
+    "fields": {
+      "rght": 7,
+      "name": "Nintendo Wii",
+      "category_uuid": "c6125cec-ef08-4095-9a07-fd5c6db50cc1",
+      "parent": 1,
+      "level": 1,
+      "lft": 2,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 3,
+    "model": "myapp.unorderedcategory",
+    "fields": {
+      "rght": 4,
+      "name": "Games",
+      "category_uuid": "85da870c-837a-48a5-a3e8-ab651cfdd799",
+      "parent": 2,
+      "level": 2,
+      "lft": 3,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 4,
+    "model": "myapp.unorderedcategory",
+    "fields": {
+      "rght": 6,
+      "name": "Hardware & Accessories",
+      "category_uuid": "840d1ccb-9ecc-48b0-bf7c-5b0f08334d3d",
+      "parent": 2,
+      "level": 2,
+      "lft": 5,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 5,
+    "model": "myapp.unorderedcategory",
+    "fields": {
+      "rght": 13,
+      "name": "Xbox 360",
+      "category_uuid": "b6299e26-d5e9-4dc2-9e2a-3f8033c8dfe5",
+      "parent": 1,
+      "level": 1,
+      "lft": 8,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 6,
+    "model": "myapp.unorderedcategory",
+    "fields": {
+      "rght": 10,
+      "name": "Games",
+      "category_uuid": "8171b0ec-f6e6-46dc-aabc-46a6399d9290",
+      "parent": 5,
+      "level": 2,
+      "lft": 9,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 7,
+    "model": "myapp.unorderedcategory",
+    "fields": {
+      "rght": 12,
+      "name": "Hardware & Accessories",
+      "category_uuid": "a64720cb-af69-440a-9abc-5a8f095974e4",
+      "parent": 5,
+      "level": 2,
+      "lft": 11,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 8,
+    "model": "myapp.unorderedcategory",
+    "fields": {
+      "rght": 19,
+      "name": "PlayStation 3",
+      "category_uuid": "01cac717-454e-48bd-8180-8a0089613bbd",
+      "parent": 1,
+      "level": 1,
+      "lft": 14,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 9,
+    "model": "myapp.unorderedcategory",
+    "fields": {
+      "rght": 16,
+      "name": "Games",
+      "category_uuid": "74f9c250-6e75-4152-bbc9-f7a89969c82b",
+      "parent": 8,
+      "level": 2,
+      "lft": 15,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 10,
+    "model": "myapp.unorderedcategory",
+    "fields": {
+      "rght": 18,
+      "name": "Hardware & Accessories",
+      "category_uuid": "a4918038-4d03-48ca-8cc3-1c28e177bed5",
+      "parent": 8,
+      "level": 2,
+      "lft": 17,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  }
+]

--- a/tests/myapp/fixtures/unordered_genres.json
+++ b/tests/myapp/fixtures/unordered_genres.json
@@ -1,0 +1,134 @@
+[
+  {
+    "pk": 1,
+    "model": "myapp.unorderedgenre",
+    "fields": {
+      "rght": 16,
+      "name": "Action",
+      "parent": null,
+      "level": 0,
+      "lft": 1,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 2,
+    "model": "myapp.unorderedgenre",
+    "fields": {
+      "rght": 9,
+      "name": "Platformer",
+      "parent": 1,
+      "level": 1,
+      "lft": 2,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 3,
+    "model": "myapp.unorderedgenre",
+    "fields": {
+      "rght": 4,
+      "name": "2D Platformer",
+      "parent": 2,
+      "level": 2,
+      "lft": 3,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 4,
+    "model": "myapp.unorderedgenre",
+    "fields": {
+      "rght": 6,
+      "name": "3D Platformer",
+      "parent": 2,
+      "level": 2,
+      "lft": 5,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 5,
+    "model": "myapp.unorderedgenre",
+    "fields": {
+      "rght": 8,
+      "name": "4D Platformer",
+      "parent": 2,
+      "level": 2,
+      "lft": 7,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 6,
+    "model": "myapp.unorderedgenre",
+    "fields": {
+      "rght": 15,
+      "name": "Shootemup",
+      "parent": 1,
+      "level": 1,
+      "lft": 10,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 7,
+    "model": "myapp.unorderedgenre",
+    "fields": {
+      "rght": 12,
+      "name": "Vertical Scrolling Shootemup",
+      "parent": 6,
+      "level": 2,
+      "lft": 11,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 8,
+    "model": "myapp.unorderedgenre",
+    "fields": {
+      "rght": 14,
+      "name": "Horizontal Scrolling Shootemup",
+      "parent": 6,
+      "level": 2,
+      "lft": 13,
+      "tree_id": "11111111-1111-1111-1111-111111111111"
+    }
+  },
+  {
+    "pk": 9,
+    "model": "myapp.unorderedgenre",
+    "fields": {
+      "rght": 6,
+      "name": "Role-playing Game",
+      "parent": null,
+      "level": 0,
+      "lft": 1,
+      "tree_id": "22222222-2222-2222-2222-222222222222"
+    }
+  },
+  {
+    "pk": 10,
+    "model": "myapp.unorderedgenre",
+    "fields": {
+      "rght": 3,
+      "name": "Action RPG",
+      "parent": 9,
+      "level": 1,
+      "lft": 2,
+      "tree_id": "22222222-2222-2222-2222-222222222222"
+    }
+  },
+  {
+    "pk": 11,
+    "model": "myapp.unorderedgenre",
+    "fields": {
+      "rght": 5,
+      "name": "Tactical RPG",
+      "parent": 9,
+      "level": 1,
+      "lft": 4,
+      "tree_id": "22222222-2222-2222-2222-222222222222"
+    }
+  }
+]

--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -37,6 +37,17 @@ class Category(MPTTModel):
     delete.alters_data = True
 
 
+class UnorderedCategory(MPTTModel):
+    class MPTTMeta:
+        root_node_ordering = False
+
+    name = models.CharField(max_length=50)
+    parent = TreeForeignKey(
+        "self", null=True, blank=True, related_name="children", on_delete=models.CASCADE
+    )
+    category_uuid = models.CharField(max_length=50, unique=True, null=True)
+
+
 class Item(models.Model):
 
     name = models.CharField(max_length=100)
@@ -67,6 +78,16 @@ class Genre(MPTTModel):
 
     def __str__(self):
         return self.name
+
+
+class UnorderedGenre(MPTTModel):
+    class MPTTMeta:
+        root_node_ordering = False
+
+    name = models.CharField(max_length=50, unique=True)
+    parent = TreeForeignKey(
+        "self", null=True, blank=True, related_name="children", on_delete=models.CASCADE
+    )
 
 
 class Game(models.Model):
@@ -364,6 +385,17 @@ class NullableOrderedInsertionModel(MPTTModel):
 
     def __str__(self):
         return self.name
+
+
+class NullableUnorderedInsertionModel(MPTTModel):
+    name = models.CharField(max_length=50, null=True)
+    parent = TreeForeignKey(
+        "self", null=True, blank=True, related_name="children", on_delete=models.CASCADE
+    )
+
+    class MPTTMeta:
+        root_node_ordering = False
+        order_insertion_by = ["name"]
 
 
 class NullableDescOrderedInsertionModel(MPTTModel):


### PR DESCRIPTION
@RedHatProductSecurity/corgi-devs This PR rebases the six commits from below:
https://github.com/django-mptt/django-mptt/compare/main...eXamadeus:django-mptt:master

Onto our own fork of django-mptt with all the latest changes, in order to fix CORGI-195. Tests appear to still be passing, and I'm going to be running this locally overnight, but sanity-check very much appreciated when you get a chance.